### PR TITLE
Issue 10 - Add Token Usage Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ codeshift -o index.go go examples/index.js
 - `-o, --output`: Specify filename to write output to
 - `-h, --help`: Display help for a command
 - `-v, --version`: Output the version number
+- `-t, --token-usage`: Output the number of tokens used
 
 ### Arguments
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ program
             const chunkContent = chunk.choices[0]?.delta?.content || "";
             process.stdout.write(chunkContent);
             response += chunkContent;
-            //Record tokens if report flag passed
+            // Record tokens if token-usage flag passed
             if (reportToken && chunk?.x_groq?.usage !== undefined) {
               prompt_tokens = chunk.x_groq.usage.prompt_tokens;
               completion_tokens = chunk.x_groq.usage.completion_tokens;
@@ -54,7 +54,7 @@ program
           for await (const chunk of responseStream) {
             const chunkContent = chunk.choices[0]?.delta?.content || "";
             process.stdout.write(chunkContent);
-            //Record tokens if report flag passed
+            // Record tokens if token-usage flag passed
             if (reportToken && chunk?.x_groq?.usage !== undefined) {
               prompt_tokens = chunk.x_groq.usage.prompt_tokens;
               completion_tokens = chunk.x_groq.usage.completion_tokens;
@@ -62,10 +62,14 @@ program
             }
           }
         }
+        // Output recorded tokens if token-usage flag passed
         if (reportToken) {
-          console.error(`\nPrompt tokens: ${prompt_tokens}`);
-          console.error(`Completion tokens: ${completion_tokens}`);
-          console.error(`Total tokens: ${total_tokens}`);
+          console.error(
+            "\nToken Usage Report:\n",
+            `Prompt tokens: ${prompt_tokens}\n`,
+            `Completion tokens: ${completion_tokens}\n`,
+            `Total tokens: ${total_tokens}`
+          );
         }
         process.stdout.write("\n");
       } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ program
   .name("codeshift")
   .description("Transform code from one language to another")
   .version(`codeshift v${version}`, "-v, --version")
-  .option("-o, --output <filename>", "specify filename to write output to");
+  .option("-o, --output <filename>", "specify filename to write output to")
+  .option("-t, --token-usage", "report token usage");
 
 // Set up default command
 program
@@ -24,19 +25,16 @@ program
   .action(async (outputLang, inputFiles) => {
     const outputFile = program.opts().output;
 
-		// Loop through file path args
+    // Loop through file path args
     for (let filePath of inputFiles) {
       try {
         const fileContent = await fs.readFile(filePath, { encoding: "utf8" });
-        const responseStream = await getGroqChatStream(
-          fileContent,
-          outputLang
-        );
-				// Check if --output flag was used
+        const responseStream = await getGroqChatStream(fileContent, outputLang);
+        // Check if --output flag was used
         if (outputFile) {
           let response = "";
-					// Read response stream one chunk at a time
-					// Store chunks in `response` for writing to output file
+          // Read response stream one chunk at a time
+          // Store chunks in `response` for writing to output file
           for await (const chunk of responseStream) {
             const chunkContent = chunk.choices[0]?.delta?.content || "";
             process.stdout.write(chunkContent);
@@ -44,7 +42,7 @@ program
           }
           await fs.writeFile(outputFile, `${response}\n`);
         } else {
-					// If no output file specified, read stream without storing to a variable
+          // If no output file specified, read stream without storing to a variable
           for await (const chunk of responseStream) {
             const chunkContent = chunk.choices[0]?.delta?.content || "";
             process.stdout.write(chunkContent);
@@ -63,10 +61,9 @@ async function getGroqChatStream(fileContent, outputLang) {
     messages: [
       {
         role: "system",
-        content:
-          `You will receive source code files and must convert them to the desired language.
+        content: `You will receive source code files and must convert them to the desired language.
           Do not include any sentences in your response. Your response must consist entirely of the requested code.
-          Do not enclose your response in a codeblock.`
+          Do not enclose your response in a codeblock.`,
       },
       {
         role: "user",


### PR DESCRIPTION
## Description:
This pull request adds a new `--token-usage` flag (with a shorthand `-t` option) to the program, allowing users to see the token usage information when making requests to the API. This flag enables the program to display the number of prompt tokens, completion tokens, and total tokens used by the request.

### Changes Made:
- Added both a long flag `--token-usage` and a short flag `-t` to the program for reporting token usage.
- Added logic to check for the `--token-usage` flag in the program. If the flag is present and the response contains token usage data, the program will now extract and display it in the console using `console.error`.
- The relevant data is extracted from `chunk?.x_groq?.usage` in the response, following GROQ API's response structure.
- Updated the README.md file to document the new `--token-usage (-t)` option.

### Notes:
- No breaking changes were introduced in this pull request.
- This PR closes #10 by adding the requested token usage option.

Please let me know if any there are any additional changes required.