### PR TITLE
Replace writeFile with appendFile for file output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,19 @@ program
   .argument("<input-files...>", "source files to read")
   .action(async (outputLang, inputFiles) => {
     const outputFile = program.opts().output;
+    // Check if file exists and contains any data
+    if (outputFile) {
+      try {
+        const fileData = await fs.readFile(outputFile, {
+          encoding: "utf8",
+        });
+        if (fileData.trim() !== "") {
+          console.warn(`File ${outputFile} is not empty, appending data....`);
+        }
+      } catch (error) {
+        // File is non-existent or can't be read, no need to handle errors.
+      }
+    }
 
     // Loop through file path args
     for (let filePath of inputFiles) {
@@ -39,19 +52,7 @@ program
             process.stdout.write(chunkContent);
             response += chunkContent;
           }
-          // Check if file exists
-          try {
-            const fileData = await fs.readFile(outputFile, {
-              encoding: "utf8",
-            });
-            if (fileData.trim() !== "") {
-              console.warn(
-                `File ${outputFile} is not empty, appending data....`
-              );
-            }
-          } catch (error) {
-            // File is non-existent or can't be read, no need to handle errors.
-          }
+          // Append response data to output file
           await fs.appendFile(outputFile, `${response}\n`);
         } else {
           // If no output file specified, read stream without storing to a variable


### PR DESCRIPTION
## Description:
This pull request modifies the program to append data to the output file when multiple input files are provided and the `--output` flag is used. Previously, the program would overwrite the output file with each input file’s data. Now, it appends the results from each input to the specified output file.

### Changes Made:
- Updated the logic to use `fs.appendFile` instead of `fs.writeFile` when multiple input files are passed along with the `--output` flag. This ensures that data from all input files is written sequentially to the same output file, rather than overwriting previous content.
- Added logic to output a warning message if the output file is not empty. File is checked using `fs.readFile` for empty check.

This fixes #12 , let me know if further changes are required.
